### PR TITLE
🔎 more accurately detect html elements

### DIFF
--- a/lib.js
+++ b/lib.js
@@ -30,7 +30,7 @@ module.exports = function (_ref, _ref2) {
   function setParentForNonHtmlElements(markdownAST) {
     visit(markdownAST, "html", function (node, index, parent) {
       if (!html.some(function (tag) {
-        return node.value == "<" + tag + ">";
+        return node.value.indexOf("<" + tag) == 0 || node.value.indexOf("</" + tag) == 0;
       })) {
         console.log("Found a custom tag " + node.value);
         parent.type = "div";

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ module.exports = ({ markdownAST }, { components }) => {
 
   function setParentForNonHtmlElements(markdownAST) {
     visit(markdownAST, "html", (node, index, parent) => {
-      if (!html.some(tag => node.value == `<${tag}>`)) {
+      if (!html.some(tag => node.value.startsWith(`<${tag}`) || node.value.startsWith(`</${tag}`))) {
         console.log("Found a custom tag " + node.value)
         parent.type = "div"
       }


### PR DESCRIPTION
The current test will fail on html elements that have attributes, like `<a href="#">` and even end tags `</div>`

This is a sloppy attempt that should address most issues.