### PR TITLE
Remove console.log's

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 const visit = require("unist-util-visit")
 import { html } from "./html-tags.js"
 
-console.log("Initializing gatsby-remark-component")
 module.exports = ({ markdownAST }, { components }) => {
   if (!components || components.length == 0) {
     setParentForNonHtmlElements(markdownAST)
@@ -29,7 +28,6 @@ module.exports = ({ markdownAST }, { components }) => {
           tag => node.value == `<${tag}>` || node.value.startsWith(`<${tag} `)
         )
       ) {
-        console.log("Found a custom tag " + node.value)
         parent.type = "div"
       }
     })


### PR DESCRIPTION
It might be a good time to remove these :)

If you prefer, it can be done using [debug](https://yarn.pm/debug), which Gatsby itself uses.